### PR TITLE
Improve URL parser to allow Facebook shares

### DIFF
--- a/PosteAPI/serializers.py
+++ b/PosteAPI/serializers.py
@@ -153,7 +153,7 @@ class PostCreateSerializer(serializers.ModelSerializer):
             return serializers.ValidationError("folder does not exist")
         return value
 
-    def validate_url(value):
+    def validate_url(self, value):
         parts = value.split()
         url = None
         for part in parts:

--- a/PosteAPI/serializers.py
+++ b/PosteAPI/serializers.py
@@ -160,6 +160,7 @@ class PostCreateSerializer(serializers.ModelSerializer):
         return value
 
     def validate_url(self, value):
+        print(f"Original link: {value}")
         parts = value.split()
         url = None
         for part in parts:
@@ -177,6 +178,7 @@ class PostCreateSerializer(serializers.ModelSerializer):
             url_validator(url)
         except ValidationError:
             raise serializers.ValidationError("Invalid URL")
+        print(f"Validated link: {url}")
         return url
 
     def validate_tags(self, value):

--- a/PosteAPI/serializers.py
+++ b/PosteAPI/serializers.py
@@ -153,19 +153,24 @@ class PostCreateSerializer(serializers.ModelSerializer):
             return serializers.ValidationError("folder does not exist")
         return value
 
-    def validate_url(self, value):
-        url_pattern = r'https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+'
-        url_list = re.findall(url_pattern, value)
-        if len(url_list) != 1:
-            raise serializers.ValidationError("invalid url")
-        url = url_list[0]
+    def validate_url(value):
+        parts = value.split()
+        url = None
+        for part in parts:
+            if 'http://' in part or 'https://' in part:
+                url = part
+                break
+            elif '.' in part:
+                url = part
+        if not url:
+            raise serializers.ValidationError("No valid URL found in the text")
         url_validator = URLValidator()
-
         try:
+            if not url.startswith('http://') and not url.startswith('https://'):
+                url = 'http://' + url
             url_validator(url)
         except ValidationError:
-            raise serializers.ValidationError("invalid url")
-
+            raise serializers.ValidationError("Invalid URL")
         return url
 
     def validate_tags(self, value):

--- a/PosteAPI/views.py
+++ b/PosteAPI/views.py
@@ -536,6 +536,7 @@ class PostAPI(APIView):
             serializer.save()
             return Response(status=status.HTTP_201_CREATED)
         else:
+            print("Error: ", serializer.errors)
             response = Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
             return response
 

--- a/PosteAPI/views.py
+++ b/PosteAPI/views.py
@@ -528,17 +528,20 @@ class PostAPI(APIView):
         },
     )
     def post(self, request, *args, **kwargs):
-        serializer = PostCreateSerializer(
-            data=request.data, context={"request": request}
-        )
-        if serializer.is_valid():
-            serializer.validated_data["creator"] = request.user
-            serializer.save()
-            return Response(status=status.HTTP_201_CREATED)
-        else:
-            print("Error: ", serializer.errors)
-            response = Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
-            return response
+        try:
+            serializer = PostCreateSerializer(
+                data=request.data, context={"request": request}
+            )
+            if serializer.is_valid():
+                serializer.validated_data["creator"] = request.user
+                serializer.save()
+                return Response(status=status.HTTP_201_CREATED)
+            else:
+                print("Error: ", serializer.errors)
+                response = Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+                return response
+        except Exception as e:
+            print("Error: ", e)
 
 
 class IndividualPostView(APIView):


### PR DESCRIPTION
Sharing from different locations (Facebook, for instance) prefixes the URL with a short string that previously didn't work with the URL parser; now, the backend will attempt to parse out the URL from a larger string so post saving doesn't fail.

This won't be perfect, but we can iterate on this using regex expressions as we iterate.

I have this working with the Facebook, X, and Reddit apps.